### PR TITLE
Revert "add lh_client_wait_for_draining_requests"

### DIFF
--- a/include/liblonghorn.h
+++ b/include/liblonghorn.h
@@ -8,6 +8,4 @@ int lh_client_close_conn(struct lh_client_conn *conn);
 
 int lh_client_read_at(struct lh_client_conn *conn, void *buf, size_t count, off_t offset);
 int lh_client_write_at(struct lh_client_conn *conn, void *buf, size_t count, off_t offset);
-
-int lh_client_wait_for_draining_requests(struct lh_client_conn *conn);
 #endif

--- a/src/longhorn_rpc_client.c
+++ b/src/longhorn_rpc_client.c
@@ -447,23 +447,3 @@ struct lh_client_conn *lh_client_allocate_conn() {
 void lh_client_free_conn(struct lh_client_conn *conn) {
         free(conn);
 }
-
-int lh_client_wait_for_draining_requests(struct lh_client_conn *conn) {
-	struct Message *elt;
-	int count;
-	int i;
-
-	for (i = 0; i < request_timeout_period; i ++) {
-		pthread_mutex_lock(&conn->msg_mutex);
-		DL_COUNT(conn->msg_list, elt, count);
-		pthread_mutex_unlock(&conn->msg_mutex);
-		if (count == 0) {
-			break;
-		}
-		sleep(1);
-	}
-	if (count != 0) {
-		errorf("timeout on waiting for draining requests, remaining requests: %d", count);
-	}
-	return count;
-}


### PR DESCRIPTION
This reverts commit 961a95721dbd83cc1053839d5cd9327668dca70d.

No longer needed with the new algorithm.