### PR TITLE
Fix use after free race conditions

### DIFF
--- a/src/longhorn_rpc_client.c
+++ b/src/longhorn_rpc_client.c
@@ -175,8 +175,8 @@ void* response_process(void *arg) {
                                         resp->Type, resp->Seq);
                         continue;
                 case TypeError:
-                        errorf("Receive error for response %d of seq %d: %s\n",
-                                        resp->Type, resp->Seq, (char *)resp->Data);
+                        errorf("Receive error for response %d of seq %d\n",
+					resp->Type, resp->Seq);
                         /* fall through so we can response to caller */
                 case TypeEOF:
                 case TypeResponse:
@@ -362,6 +362,8 @@ int process_request(struct lh_client_conn *conn, void *buf, size_t count, off_t 
         }
 out:
         pthread_mutex_unlock(&req->mutex);
+        // need to clean up in case send_request() failed
+        find_and_remove_request_from_queue(conn, req->Seq);
 free:
         free(req);
         return rc;


### PR DESCRIPTION
The issue will happen if the error path was triggered. The
`process_request` function didn't remove the request from the queue when
immediate failure `send_request` happened (may due to the connection
closed), so `req` was freed before it was removed from the queue, cause
"use after free" in `lh_client_close_conn` and `add_request_in_queue`
(indirectly caused by empty element in the hashtable or list).

This commit also fixes a NPE caused by trying to print the error message
without checking the message exists or not.

This commit fixes the TGTD `segmentation fault` issue.

https://github.com/longhorn/longhorn/issues/424