### PR TITLE
Change Architecture to support build on ARM

### DIFF
--- a/scripts/deb/control
+++ b/scripts/deb/control
@@ -6,7 +6,7 @@ Standards-Version: 0.1
 Build-Depends: debhelper (>= 9)
 
 Package: liblonghorn
-Architecture: amd64
+Architecture: any
 Depends: ${misc:Depends}
 Description: Longhorn development library
  Use to communicate with Longhorn controller.


### PR DESCRIPTION
I'm working on longhorn/longhorn#6. This change is required to build the library on ARM.