### PR TITLE
[#6] Add `all` dependency to `install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ distclean:
 	rm -rf pkg/
 	rm -f $(OBJECTS) $(OUTPUT_FILE)
 
-install:
+install: all
 	mkdir -p $(INSTALL_LIB_DIR)
 	cp -p $(OUTPUT_FILE) $(INSTALL_LIB_DIR)
 	mkdir -p $(INSTALL_HEADER_DIR)


### PR DESCRIPTION
Trivial build improvement so that call to the `install` target succeeds
without prior invocation of make.
