### PR TITLE
[#8] Fix rancher/tgt cross-build with rpi toolchain

### DIFF
--- a/include/liblonghorn.h
+++ b/include/liblonghorn.h
@@ -1,7 +1,7 @@
 #ifndef LIBLONGHORN_HEADER
 #define LIBLONGHORN_HEADER
 
-struct lh_client_conn *lh_client_allocate_conn();
+struct lh_client_conn *lh_client_allocate_conn(void);
 void lh_client_free_conn(struct lh_client_conn *conn);
 int lh_client_open_conn(struct lh_client_conn *conn, char *socket_path);
 int lh_client_close_conn(struct lh_client_conn *conn);


### PR DESCRIPTION
Add explicit void argument list in lh_client_allocate_conn function
declaration.

Older gcc version (the one used in the current raspberrypi tool chain)
requires it.

This is required to cross-build tgt.