### PR TITLE
Change timeout to be the time between receiving any response message.

### DIFF
--- a/src/longhorn_rpc_protocol.h
+++ b/src/longhorn_rpc_protocol.h
@@ -24,7 +24,6 @@ struct Message {
         UT_hash_handle  hh;
 
         struct Message *next, *prev;
-        struct timespec expiration;
 };
 
 enum uint32_t {


### PR DESCRIPTION
This change makes liblonghorn timeout when there are pending operations and liblonghorn has not received a response from any of the pending operations for 15 seconds.  Previously, each operation had an individual timeout value.  This change allows operations that take longer so long as operations are still completing.